### PR TITLE
Added url parameter for specifying a different URL in constructor

### DIFF
--- a/fastbill/__init__.py
+++ b/fastbill/__init__.py
@@ -87,7 +87,11 @@ class FastbillWrapper(object):
 
     SERVICE_URL = "https://automatic.fastbill.com/api/1.0/api.php"
 
-    def __init__(self, email, api_key):
+    def __init__(self, email, api_key, url = None):
+
+        if not url is None:
+            self.SERVICE_URL = url
+
         self.auth = (email, api_key)
         self.headers = {'Content-Type': 'application/json'}
 


### PR DESCRIPTION
If you don't want to use FastBill automatic but rather the core FastBill API, you can now specify the URL via the wrapper constructor.
